### PR TITLE
Bump the rubygem versions used to test this module

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,11 +3,11 @@ source 'https://rubygems.org'
 # Versions can be overridden with environment variables for matrix testing.
 # Travis will remove Gemfile.lock before installing deps.
 
-gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.2.0'
+gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.8.6'
 
 gem 'rake'
-gem 'puppet-lint'
-gem 'rspec-puppet'
+gem 'puppet-lint', '1.1.0'
+gem 'rspec-puppet', '2.2.0'
 gem 'rspec-system-puppet'
-gem 'puppetlabs_spec_helper'
-gem 'puppet-syntax'
+gem 'puppetlabs_spec_helper', '1.1.1'
+gem 'puppet-syntax', '2.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,39 +1,40 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    CFPropertyList (2.2.8)
     builder (3.2.2)
     diff-lcs (1.2.4)
-    facter (1.7.1)
-    hiera (1.2.1)
+    facter (2.4.6)
+      CFPropertyList (~> 2.2.6)
+    hiera (1.3.4)
       json_pure
-    json_pure (1.8.0)
+    json_pure (1.8.3)
     kwalify (0.7.2)
-    metaclass (0.0.1)
-    mocha (0.14.0)
+    metaclass (0.0.4)
+    mocha (1.1.0)
       metaclass (~> 0.0.1)
     net-scp (1.1.1)
       net-ssh (>= 2.6.5)
     net-ssh (2.6.7)
     nokogiri (1.5.10)
-    puppet (3.2.2)
-      facter (~> 1.6)
+    puppet (3.8.6)
+      facter (> 1.6, < 3)
       hiera (~> 1.0)
-      rgen (~> 0.6)
-    puppet-lint (0.3.2)
-    puppet-syntax (0.0.4)
-      puppet (>= 2.7.0)
+      json_pure
+    puppet-lint (1.1.0)
+    puppet-syntax (2.1.0)
       rake
-    puppetlabs_spec_helper (0.4.1)
-      mocha (>= 0.10.5)
+    puppetlabs_spec_helper (1.1.1)
+      mocha
+      puppet-lint
+      puppet-syntax
       rake
-      rspec (>= 2.9.0)
-      rspec-puppet (>= 0.1.1)
+      rspec-puppet
     rake (10.1.0)
     rbvmomi (1.6.0)
       builder
       nokogiri (>= 1.4.1)
       trollop
-    rgen (0.6.5)
     rspec (2.13.0)
       rspec-core (~> 2.13.0)
       rspec-expectations (~> 2.13.0)
@@ -42,7 +43,7 @@ GEM
     rspec-expectations (2.13.0)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.13.1)
-    rspec-puppet (0.1.6)
+    rspec-puppet (2.2.0)
       rspec
     rspec-system (2.1.0)
       kwalify (~> 0.7.2)
@@ -61,10 +62,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  puppet (~> 3.2.0)
-  puppet-lint
-  puppet-syntax
-  puppetlabs_spec_helper
+  puppet (~> 3.8.6)
+  puppet-lint (= 1.1.0)
+  puppet-syntax (= 2.1.0)
+  puppetlabs_spec_helper (= 1.1.1)
   rake
-  rspec-puppet
+  rspec-puppet (= 2.2.0)
   rspec-system-puppet
+
+BUNDLED WITH
+   1.11.2


### PR DESCRIPTION
As a first pass at making this module run under puppet 4
we need to bump the testing modules to newer, v4 supporting
versions. These are currently the latest modules we've had
success with in other puppet 4 module updates.